### PR TITLE
Added optional results file name change parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Then you have to specify the logger to use when executing the tool with the `Log
     vstest.console.exe ... /Logger:MsTestTrxLogger
 
 Optional parameter for MsTestTrxLogger: `LogFileName`, for if you want to specify the name and path of the output .trx file.
-	
-	```vstest.console.exe ... /Logger:MsTestTrxLogger;LogFileName=<NameOfTestResultsFile.trx>```
+
+	vstest.console.exe ... /Logger:MsTestTrxLogger;LogFileName=<NameOfTestResultsFile.trx>
 
 ### Getting the binaries
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Then you have to specify the logger to use when executing the tool with the `Log
 
     vstest.console.exe ... /Logger:MsTestTrxLogger
 
+Optional parameter for MsTestTrxLogger: `LogFileName`, for if you want to specify the name and path of the output .trx file.
+	
+	```vstest.console.exe ... /Logger:MsTestTrxLogger;LogFileName=<NameOfTestResultsFile.trx>```
+
 ### Getting the binaries
 
 You can get the binaries either by cloning this repo and building the project, or by downloading them from the [Releases](https://github.com/markvincze/MsTestTrxLogger/releases) page.

--- a/src/MsTestTrxLogger/MsTestTrxLogger.cs
+++ b/src/MsTestTrxLogger/MsTestTrxLogger.cs
@@ -61,7 +61,7 @@ namespace MsTestTrxLogger
                 {
                     var trxOutputWriter = new MsTestTrxXmlWriter(testResults, args, testRunStarted);
 
-                    trxOutputWriter.WriteTrxOutput(testRunDirectory, trxFilePath);
+                    trxOutputWriter.WriteTrxOutput(trxFilePath);
                 }
                 catch (Exception ex)
                 {

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -31,7 +31,7 @@ namespace MsTestTrxLogger
             this.testRunStarted = testRunStarted;
         }
 
-        public void WriteTrxOutput(string outputDirectoryPath)
+        public void WriteTrxOutput(string outputDirectoryPath, string trxFilePath)
         {
             Console.WriteLine("Starting to generate trx XML output.");
 
@@ -113,17 +113,9 @@ namespace MsTestTrxLogger
 
             Console.WriteLine("XML generation done, saving the trx files.");
 
-            var trxResultFilePath = Path.Combine(
-                outputDirectoryPath,
-                String.Format(
-                    "{0}_{1} {2}.trx",
-                    Environment.UserName,
-                    Environment.MachineName,
-                    DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss")));
+            File.WriteAllText(trxFilePath, doc.ToString());
 
-            File.WriteAllText(trxResultFilePath, doc.ToString());
-
-            Console.WriteLine("Results File: {0}", trxResultFilePath);
+            Console.WriteLine("Results File: {0}", trxFilePath);
         }
 
         private static void CleanXmlNamespaces(XDocument doc)

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -31,7 +31,7 @@ namespace MsTestTrxLogger
             this.testRunStarted = testRunStarted;
         }
 
-        public void WriteTrxOutput(string outputDirectoryPath, string trxFilePath)
+        public void WriteTrxOutput(string trxFilePath)
         {
             Console.WriteLine("Starting to generate trx XML output.");
 


### PR DESCRIPTION
I have added the option of specifying the name of the output .trx file.

It was functionality I needed and thought others may desire it in future.

Most of the code was taken from the trx logger which ships with vstest as that also has this optional parameter.