### PR TITLE
Fix inconsistencies with Trx file format

### DIFF
--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -13,7 +13,7 @@ namespace MsTestTrxLogger
     public class MsTestTrxXmlWriter
     {
         private const string adapterTypeName = "Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-        
+
         private const string unitTestTypeGuid = "13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B";
 
         private readonly IList<TestResult> testResults;
@@ -102,7 +102,7 @@ namespace MsTestTrxLogger
                             new XAttribute("testId", UnitTestIdGenerator.GuidFromString(result.TestCase.FullyQualifiedName)),
                             new XAttribute("testListId", testRunId.ToString())))),
                       new XElement("TestLists",
-                        new XElement("TestList", new XAttribute("id", testRunId.ToString()), new XAttribute("name", "Test list"))),
+                        new XElement("TestList", new XAttribute("id", testRunId.ToString()), new XAttribute("name", "All Loaded Results"))),
                       new XElement("Times",
                         new XAttribute("creation", testRunStarted.ToString("o")),
                         new XAttribute("finish", DateTime.Now.ToString("o")),

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -104,7 +104,7 @@ namespace MsTestTrxLogger
                       new XElement("Times",
                         new XAttribute("creation", testRunStarted.ToString("o")),
                         new XAttribute("finish", DateTime.Now.ToString("o")),
-                        new XAttribute("queueing", testRunStarted.ToString("o")),
+                        new XAttribute("queuing", testRunStarted.ToString("o")),
                         new XAttribute("start", testRunStarted.ToString("o")))
                     ));
 

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -13,6 +13,8 @@ namespace MsTestTrxLogger
     public class MsTestTrxXmlWriter
     {
         private const string adapterTypeName = "Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+        
+        private const string unitTestTypeGuid = "13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B";
 
         private readonly IList<TestResult> testResults;
 
@@ -55,7 +57,7 @@ namespace MsTestTrxLogger
                             new XAttribute("testId", UnitTestIdGenerator.GuidFromString(result.TestCase.FullyQualifiedName)),
                             new XAttribute("testListId", testRunId.ToString()),
                             new XAttribute("testName", result.TestCase.DisplayName),
-                            new XAttribute("testType", testRunId.ToString()),
+                            new XAttribute("testType", unitTestTypeGuid),
                             GetOutputElement(result)))),
                     new XElement("ResultSummary",
                         new XAttribute("outcome", completeEventArgs.IsAborted ? "Aborted" : completeEventArgs.IsCanceled ? "Canceled" : "Completed"),

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -99,7 +99,7 @@ namespace MsTestTrxLogger
                       new XElement("TestEntries",
                         testResults.Select(result => new XElement("TestEntry",
                             new XAttribute("executionId", GetExecutionId(result)),
-                            new XAttribute("testId", UnitTestIdGenerator.GuidFromString(result.TestCase.DisplayName)),
+                            new XAttribute("testId", UnitTestIdGenerator.GuidFromString(result.TestCase.FullyQualifiedName)),
                             new XAttribute("testListId", testRunId.ToString())))),
                       new XElement("TestLists",
                         new XElement("TestList", new XAttribute("id", testRunId.ToString()), new XAttribute("name", "Test list"))),


### PR DESCRIPTION
Trx files created by MsTestTrxLogger cannot be opened on Visual Studio.

Identified issues fixed on this pull request:
* Typo in queuing (already highlighted on pull request https://github.com/markvincze/MsTestTrxLogger/pull/5)
* Unit Test Type GUID shouldn't be a random GUID
* Test Entry testID didn't match the expected Fully Qualified Name
* Updated default Test List name. This shouldn't affect the validity of the generated Trx file.