### PR TITLE
VsTest changes

### DIFF
--- a/src/MsTestTrxLogger/MsTestTrxLogger.cs
+++ b/src/MsTestTrxLogger/MsTestTrxLogger.cs
@@ -46,10 +46,7 @@ namespace MsTestTrxLogger
             {
                 try
                 {
-                    if (!IsTestIgnored(eventArgs.Result))
-                    {
-                        testResults.Add(eventArgs.Result);
-                    }
+                    testResults.Add(eventArgs.Result);                    
                 }
                 catch (Exception ex)
                 {
@@ -106,13 +103,5 @@ namespace MsTestTrxLogger
                     DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss")));
         }
 
-        /// <summary>
-        /// Returns whether the test was ignored or not.
-        /// </summary>
-        /// <remarks>
-        /// The object model doesn't indicate whether a test was ignored with an IgnoreAttribute, or was skipped for other reasons.
-        /// It seems to be a reliable way to recognize if a test was actually ignored if we check whether the number of its Messages id 0.
-        /// </remarks>
-        private bool IsTestIgnored(TestResult test) => test.Outcome == TestOutcome.Skipped && test.Messages.Count == 0;
     }
 }

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -51,7 +51,7 @@ namespace MsTestTrxLogger
                             new XAttribute("duration", result.Duration.ToString()),
                             new XAttribute("endTime", result.EndTime.ToString("o")),
                             new XAttribute("executionId", GetExecutionId(result)),
-                            new XAttribute("outcome", result.Outcome == TestOutcome.Skipped ? "Inconclusive" : result.Outcome.ToString()),
+                            new XAttribute("outcome", result.Outcome == TestOutcome.Skipped ? "NotExecuted" : result.Outcome.ToString()),
                             new XAttribute("relativeResultsDirectory", GetExecutionId(result)),
                             new XAttribute("startTime", result.StartTime.ToString("o")),
                             new XAttribute("testId", UnitTestIdGenerator.GuidFromString(result.TestCase.FullyQualifiedName)),

--- a/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
+++ b/src/MsTestTrxLogger/MsTestTrxXmlWriter.cs
@@ -90,7 +90,7 @@ namespace MsTestTrxLogger
                                     new XElement("Key", p.Name),
                                     new XElement("Value", p.Value)))),
                             new XElement("TestCategory",
-                                GetTestCategory(result).Select(c => new XElement("TestCategoryItem", c.TestCategories.First()))),
+                                GetTestCategory(result).SelectMany( c => c.TestCategories).Select(c => new XElement("TestCategoryItem", c))),
                             new XElement("TestMethod",
                                 new XAttribute("adapterTypeName", adapterTypeName),
                                 new XAttribute("className", GetClassFullName(result)),
@@ -242,7 +242,7 @@ namespace MsTestTrxLogger
         /// The information in the TestCategoryAttributes (<see cref="Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute" />) is not present
         /// in the object model provided in Microsoft.VisualStudio.TestPlatform.ObjectModel, so we have to look it up in the unit test assembly.
         /// </remarks>
-        private IEnumerable<TestCategoryAttribute> GetTestCategory(TestResult test)
+        private IEnumerable<TestCategoryBaseAttribute> GetTestCategory(TestResult test)
         {
             var assembly = GetAssembly(test.TestCase.Source);
 
@@ -253,7 +253,7 @@ namespace MsTestTrxLogger
 
             var method = type.GetMethod(methodName);
 
-            return method.GetCustomAttributes<TestCategoryAttribute>();
+            return method.GetCustomAttributes<TestCategoryBaseAttribute>();
         }
 
         /// <summary>


### PR DESCRIPTION
Trx files created by MsTestTrxLogger has some differneces in compare to the original logger:

- Ignored tests are not output to TRX file into **TestRun\Results** section.
- Ignored tests are market as **outcome=Inconclusive** instead of **NotExecuted**
- Only the first Test Category value is output
- Test category is not output if the custom class was inherited from **TestCategoryBaseAttribute**

The issues were fixed
